### PR TITLE
Fix a flaky test.

### DIFF
--- a/src/test/java/com/braintreegateway/unittest/RequestBuilderTest.java
+++ b/src/test/java/com/braintreegateway/unittest/RequestBuilderTest.java
@@ -3,7 +3,7 @@ package com.braintreegateway.unittest;
 import com.braintreegateway.RequestBuilder;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -46,7 +46,7 @@ public class RequestBuilderTest {
     @Test
     public void map() {
         Open builder = new Open();
-        Map<String, Object> map = new HashMap<String, Object>();
+        Map<String, Object> map = new LinkedHashMap<String, Object>();
         map.put("color", "green");
         map.put("insect", "bee");
         String element = builder.formatMap("examples", map);


### PR DESCRIPTION
1. The test failure:
- Run the test `com.braintreegateway.unittest.RequestBuilderTest#map` with `mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=com.braintreegateway.unittest.RequestBuilderTest#map`
- Get some failures:
```
[ERROR] Failures:
[ERROR] RequestBuilderTest.map:53 expected: <<examples><color>green</color><insect>bee</insect></examples>> but was: <<examples><insect>bee</insect><color>green</color></examples>>
```
- About [NonDex](https://github.com/TestingResearchIllinois/NonDex).

2. Why it fails:
- In `src/test/java/com/braintreegateway/unittest/RequestBuilderTest.java` : `Map<String, Object> map = new HashMap<String, Object>();` HashMap makes no guarantee about the iteration order.
3. Fix it:
- By changing `HashMap` to `LinkedHashMap`.